### PR TITLE
Filter out hourly salaries 

### DIFF
--- a/data/data_to_db.py
+++ b/data/data_to_db.py
@@ -5,6 +5,8 @@ import os
 import wget
 from xlsx2csv import Xlsx2csv
 
+MIN_SALARY = 15080
+
 name = sys.argv[1]
 url = sys.argv[2]
 
@@ -53,7 +55,7 @@ cleaned_sheet = cleaned_sheet[cleaned_sheet["VISA_CLASS"] == "H-1B"]
 cleaned_sheet = cleaned_sheet[cleaned_sheet["PREVAILING_WAGE"].notnull()]
 cleaned_sheet = cleaned_sheet[cleaned_sheet["CASE_STATUS"] == "CERTIFIED"]
 cleaned_sheet = cleaned_sheet[cleaned_sheet["FULL_TIME_POSITION"] == "Y"]
-cleaned_sheet = cleaned_sheet[cleaned_sheet["PREVAILING_WAGE"] > 15080]
+cleaned_sheet = cleaned_sheet[cleaned_sheet["PREVAILING_WAGE"] > MIN_SALARY]
 cleaned_sheet["EMPLOYMENT_START_DATE"] = pd.to_datetime(
     cleaned_sheet["EMPLOYMENT_START_DATE"]
 ).dt.date


### PR DESCRIPTION
# What
- added another filter in the data ingestion script to filter out hourly salaries
- hard cutoff is set at $15080
  - calculated from a full-time worker making federal minimum wage: $7.25/hr * 40hrs/week * 52 weeks/yr

# Why
- we only want yearly values in our database